### PR TITLE
(doc) Fix markdown formatting

### DIFF
--- a/dcm.nuspec
+++ b/dcm.nuspec
@@ -19,29 +19,29 @@
       This executable is for Teams version which requires a license to work. You can also request a trial version.
     </summary>
     <description>
-      DCM is a toolkit that helps you identify and fix problems in your Dart and Flutter code. These problems can range from potential runtime bugs and violations of best practices to styling issues. DCM includes over 70 built-in rules to validate your code against various expectations, and you can customize these rules to fit your specific needs.
+DCM is a toolkit that helps you identify and fix problems in your Dart and Flutter code. These problems can range from potential runtime bugs and violations of best practices to styling issues. DCM includes over 70 built-in rules to validate your code against various expectations, and you can customize these rules to fit your specific needs.
 
-      ## Rules
-      Rules are central to how DCM works. They are used to check whether your code meets certain expectations, and to specify what should be done if it doesn't. Rules can also be configured with additional options specific to that rule.
+## Rules
+Rules are central to how DCM works. They are used to check whether your code meets certain expectations, and to specify what should be done if it doesn't. Rules can also be configured with additional options specific to that rule.
       
-      For more information, see the [Rules](https://dcm.dev/docs/individuals/rules/) documentation.
+For more information, see the [Rules](https://dcm.dev/docs/individuals/rules/) documentation.
       
-      ## Metrics
-      Metrics are another important aspect of DCM. They are used to measure the complexity of your code and identify areas that may be difficult to maintain or test. This can be particularly useful for larger projects, where it can be challenging to keep track of all the different contributions from various developers. Metrics can also provide instant feedback on pull requests for smaller projects, helping to ensure that code stays easy to maintain.
+## Metrics
+Metrics are another important aspect of DCM. They are used to measure the complexity of your code and identify areas that may be difficult to maintain or test. This can be particularly useful for larger projects, where it can be challenging to keep track of all the different contributions from various developers. Metrics can also provide instant feedback on pull requests for smaller projects, helping to ensure that code stays easy to maintain.
       
-      All metrics are configurable.
+All metrics are configurable.
       
-      For more information, see the [Metrics](https://dcm.dev/docs/individuals/metrics/) documentation.
+For more information, see the [Metrics](https://dcm.dev/docs/individuals/metrics/) documentation.
       
-      ## Commands
-      In addition to providing rules and metrics, DCM also includes commands to help with codebase maintenance, such as identifying unused code, unused files, and unused localization.
+## Commands
+In addition to providing rules and metrics, DCM also includes commands to help with codebase maintenance, such as identifying unused code, unused files, and unused localization.
       
-      For more information, see the [CLI](https://dcm.dev/docs/individuals/cli/) documentation.
+For more information, see the [CLI](https://dcm.dev/docs/individuals/cli/) documentation.
       
-      ## Configuration
-      DCM is designed to be flexible and configurable to fit your specific needs. You can choose to enable only metrics calculation, only rules, or both.
+## Configuration
+DCM is designed to be flexible and configurable to fit your specific needs. You can choose to enable only metrics calculation, only rules, or both.
       
-      For more information, see the [Configuration](https://dcm.dev/docs/individuals/configuration/) documentation.
+For more information, see the [Configuration](https://dcm.dev/docs/individuals/configuration/) documentation.
     </description>
   </metadata>
   <files>


### PR DESCRIPTION
Start all lines in the description section at the start of the line.

This will make the rendering on the site work correctly.

Rather that what is currently happening:

<img width="674" alt="image" src="https://github.com/CQLabs/choco-dcm/assets/1271146/87804f57-d522-48eb-8a97-d1098bbc866e">
